### PR TITLE
Add WarriorTrained Event

### DIFF
--- a/contracts/WarriorBase.sol
+++ b/contracts/WarriorBase.sol
@@ -68,6 +68,7 @@ contract WarriorBase {
         return duration;
     }
 
+    event WarriorTrained( address owner, uint warriorId,  uint xp);
     function trainWarrior(uint warriorId) public {
         require(
             warriorId >= 0 &&
@@ -79,6 +80,7 @@ contract WarriorBase {
           lastTrainedDuration >= 1
         );
         warriors[warriorId].xp += 100;
+        emit WarriorTrained(msg.sender,warriorId,warriors[warriorId].xp);
     }
 
 }


### PR DESCRIPTION
Issue: 9


#### Short description of what this resolves:
Emit the warrior trained event when a warrior is trained

#### Changes proposed in this pull request and/or Screenshots of changes:

- Warrior trained event will be emitted with owner address, warrior id and xp when the warrior is trained.
-
-
